### PR TITLE
Fixes for config changes, WebSockets presets update

### DIFF
--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -158,12 +158,13 @@
             <PreferenceCategory
                     android:title="@string/preferenceCategory_security_title"
                     >
-                <CheckBoxPreference
-                        android:key="@string/preferenceKey_connection_useMTM"
-                        android:title="@string/checkBoxPreference_connection_useMTM_title"
-                        android:summary="@string/checkBoxPreference_connection_useMTM_summary"
-                        android:defaultValue="@string/preferenceValue_connection_useMTM"
-                        />
+                <!-- Commented this out until we get MTM/WebSocket issues ironed out -->
+                <!--<CheckBoxPreference-->
+                        <!--android:key="@string/preferenceKey_connection_useMTM"-->
+                        <!--android:title="@string/checkBoxPreference_connection_useMTM_title"-->
+                        <!--android:summary="@string/checkBoxPreference_connection_useMTM_summary"-->
+                        <!--android:defaultValue="@string/preferenceValue_connection_useMTM"-->
+                        <!--/>-->
                 <CheckBoxPreference
                         android:key="@string/preferenceKey_connection_showEncryption"
                         android:title="@string/checkBoxPreference_connection_showEncryption_title"

--- a/src/org/mitre/svmp/apprtc/AppRTCHelper.java
+++ b/src/org/mitre/svmp/apprtc/AppRTCHelper.java
@@ -100,13 +100,13 @@ public class AppRTCHelper {
         AppRTCSignalingParameters value = null;
 
         try {
-            MediaConstraints pcConstraints = constraintsFromJSON(jsonObject.getJSONObject("pcConstraints"));
-            Log.d(TAG, "pcConstraints: " + pcConstraints);
+            MediaConstraints pcConstraints = constraintsFromJSON(jsonObject.getJSONObject("pc"));
+            Log.d(TAG, "pc constraints: " + pcConstraints);
 
-            MediaConstraints videoConstraints = constraintsFromJSON(jsonObject.getJSONObject("videoConstraints"));
-            Log.d(TAG, "videoConstraints: " + videoConstraints);
+            MediaConstraints videoConstraints = constraintsFromJSON(jsonObject.getJSONObject("video"));
+            Log.d(TAG, "video constraints: " + videoConstraints);
 
-            LinkedList<IceServer> iceServers = iceServersFromPCConfigJSON(jsonObject.getJSONArray("iceServers"));
+            LinkedList<IceServer> iceServers = iceServersFromPCConfigJSON(jsonObject.getJSONArray("ice_servers"));
             value = new AppRTCSignalingParameters(iceServers, true, pcConstraints, videoConstraints);
         } catch (JSONException e) {
             Log.e(TAG, "getParametersForRoom failed:", e);

--- a/src/org/mitre/svmp/common/Constants.java
+++ b/src/org/mitre/svmp/common/Constants.java
@@ -26,7 +26,7 @@ public interface Constants {
     // this password is used to open that file
     public static final String TRUSTSTORE_PASSWORD = "changeme_clienttstorepass";
 
-    public static final int DEFAULT_PORT = 8002;
+    public static final int DEFAULT_PORT = 3000;
     public static final String ACTION_REFRESH = "org.mitre.svmp.ACTION_REFRESH"; // causes SvmpActivity to refresh its layout
     public static final String ACTION_STOP_SERVICE = "org.mitre.svmp.ACTION_STOP_SERVICE"; // causes
     public static final String ACTION_LAUNCH_APP = "org.mitre.svmp.LAUNCH_APP";


### PR DESCRIPTION
Updated AppRTCHelper to support new format for WebRTC message
(variable names changed).
Removed MemorizingTrustManager option from preferences since it is
currently unused in the socket connection code.
Changed default port for connection to 3000 to match SVMP Overseer
default port.
